### PR TITLE
Fix fixup function for case that import path of package has different…

### DIFF
--- a/type.go
+++ b/type.go
@@ -129,10 +129,16 @@ func fixup(typ *Type, q *Query) {
 	// Should be fixed layer below, in type.go.
 
 	// when include other package struct
-	if typ.ImportPath != "" && typ.ImportPath != q.Package && typ.IsComposite {
-		pkgIdx := strings.LastIndex(typ.ImportPath, typ.Package)
-		if 0 < pkgIdx {
-			typ.Name = strings.Replace(typ.Name, typ.ImportPath[:pkgIdx], "", -1)
+	if typ.ImportPath != "" && typ.IsComposite {
+		if typ.ImportPath == q.Package {
+			typ.Name = strings.Replace(typ.Name, typ.ImportPath, typ.Package, -1)
+		}
+
+		if typ.ImportPath != q.Package {
+			pkgIdx := strings.LastIndex(typ.ImportPath, typ.Package)
+			if 0 < pkgIdx {
+				typ.Name = strings.Replace(typ.Name, typ.ImportPath[:pkgIdx], "", -1)
+			}
 		}
 	}
 

--- a/type_test.go
+++ b/type_test.go
@@ -203,6 +203,21 @@ func Test_fixup(t *testing.T) {
 			},
 			fixed: "WithMap2(*[]map[string]*hoge.Hoge)",
 		},
+		"func (s *Sample) ListBuckets() ([]minio.BucketInfo)": {
+			typ: &Type{
+				Name:        "[]github.com/minio/minio-go/v6.BucketInfo",
+				Package:     "minio",
+				ImportPath:  "github.com/minio/minio-go/v6",
+				IsPointer:   false,
+				IsComposite: true,
+				IsFunc:      false,
+			},
+			q: &Query{
+				TypeName: "Client",
+				Package:  "github.com/minio/minio-go/v6",
+			},
+			fixed: "[]minio.BucketInfo",
+		},
 	}
 
 	for k, c := range cases {


### PR DESCRIPTION
Initial problem: 
Parameter of struct function is imported. This imported package folder is different to its package name.

Example:
interfacer -for github.com/minio/minio-go/v6.Client -as contentservice.MinioClient -o minio_client_interface.go