### PR TITLE
Remove executable bit from generated files

### DIFF
--- a/cmd/interfacer/main.go
+++ b/cmd/interfacer/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 	f := os.Stdout
 	if *output != "-" {
-		f, err = os.OpenFile(*output, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0755)
+		f, err = os.OpenFile(*output, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			die(err)
 		}

--- a/cmd/structer/main.go
+++ b/cmd/structer/main.go
@@ -123,7 +123,7 @@ func run() (err error) {
 
 	w := os.Stdout
 	if *output != "-" {
-		w, err = os.OpenFile(*output, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0755)
+		w, err = os.OpenFile(*output, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Generated files (go source code) should _not_ set executable flag set.