### PR TITLE
Format generated file with goimports

### DIFF
--- a/cmd/interfacer/main.go
+++ b/cmd/interfacer/main.go
@@ -91,6 +91,11 @@ func main() {
 		if err != nil {
 			die(err)
 		}
+		defer func() {
+			if err := interfaces.FormatFile(*output); err != nil {
+				die(err)
+			}
+		}()
 	}
 	err = nonil(tmpl.Execute(f, v), f.Close())
 	if err != nil {

--- a/cmd/structer/main.go
+++ b/cmd/structer/main.go
@@ -127,6 +127,11 @@ func run() (err error) {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err == nil {
+				err = interfaces.FormatFile(*output)
+			}
+		}()
 	}
 
 	if *typ == "" {

--- a/imports.go
+++ b/imports.go
@@ -1,0 +1,20 @@
+package interfaces
+
+import (
+	"io/ioutil"
+
+	"golang.org/x/tools/imports"
+)
+
+// FormatFile runs goimports on given filename.
+func FormatFile(filename string) error {
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	src, err := imports.Process(filename, buf, nil)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, src, 0644)
+}


### PR DESCRIPTION
Ensure generated code is properly formatted by running `imports.Process` (formatting library goimports uses).