### PR TITLE
Fix import paths that are in vendor

### DIFF
--- a/type.go
+++ b/type.go
@@ -143,4 +143,15 @@ func fixup(typ *Type, q *Query) {
 	}
 
 	typ.Name = strings.Replace(typ.Name, q.Package, path.Base(q.Package), -1)
+	typ.ImportPath = trimVendorPath(typ.ImportPath)
+}
+
+// trimVendorPath removes the vendor dir prefix from a package path.
+// example: github.com/foo/bar/vendor/github.com/pkg/errors -> github.com/pkg/errors.
+func trimVendorPath(p string) string {
+	parts := strings.Split(p, "/vendor/")
+	if len(parts) == 1 {
+		return p
+	}
+	return strings.TrimLeft(path.Join(parts[1:]...), "/")
 }


### PR DESCRIPTION
At now, `interfacer` generates import paths like the following:

```go
// Code generated by interfacer; DO NOT EDIT

package main

import (
        "database/sql"
	"<my_repository>/vendor/github.com/pkg/errors"
)

// ...
```

This PR fix it like the following:

```go
// Code generated by interfacer; DO NOT EDIT

package main

import (
        "database/sql"
	"github.com/pkg/errors"
)

// ...
```

I referred to https://github.com/matryer/moq/pull/122 and https://github.com/matryer/moq/issues/18 for resolving this issue.